### PR TITLE
Specify the version of django-autocomplete-light

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django<1.10
 
 django-allauth
-django-autocomplete-light
+django-autocomplete-light>=2.0,<3.0
 django-crispy-forms
 django-extensions
 django-el-pagination


### PR DESCRIPTION
The version 2.x.x is stable whereas the version 3 is not and break this
project.

Ref #5
