### PR TITLE
Add some links to add organization objects when it doesn't exist

### DIFF
--- a/ain7/organizations/autocomplete_light_registry.py
+++ b/ain7/organizations/autocomplete_light_registry.py
@@ -31,6 +31,7 @@ from ain7.organizations.models import (
 autocomplete_light.register(
     Office,
     search_fields=['name', 'organization__name'],
+    add_another_url_name='organization-add',
 )
 autocomplete_light.register(Organization)
 autocomplete_light.register(OrganizationActivityField, search_fields=['label'])

--- a/ain7/organizations/autocomplete_light_registry.py
+++ b/ain7/organizations/autocomplete_light_registry.py
@@ -34,4 +34,8 @@ autocomplete_light.register(
     add_another_url_name='organization-add',
 )
 autocomplete_light.register(Organization)
-autocomplete_light.register(OrganizationActivityField, search_fields=['label'])
+autocomplete_light.register(
+    OrganizationActivityField,
+    search_fields=['label', 'field'],
+    add_another_url_name='organization-activity-add',
+)

--- a/ain7/organizations/models.py
+++ b/ain7/organizations/models.py
@@ -52,6 +52,9 @@ class OrganizationActivityField(models.Model):
         """activity field unicode"""
         return self.field
 
+    def get_absolute_url(self):
+        return reverse('organization-activity-edit', kwargs={'pk': self.pk})
+
     class Meta:
         """activity field meta"""
         verbose_name = _('Activity field')

--- a/ain7/organizations/urls.py
+++ b/ain7/organizations/urls.py
@@ -22,9 +22,12 @@
 #
 
 from django.conf.urls import url
+from django.views import generic
 
+import autocomplete_light.shortcuts as al
 
 from ain7.organizations import views
+from ain7.organizations.models import OrganizationActivityField
 
 urlpatterns = [
 
@@ -47,6 +50,18 @@ urlpatterns = [
         r'^(?P<org1_id>\d+)/merge/(?P<org2_id>\d+)/$',
         views.organization_merge_perform,
         name='organization-merge-perform',
+    ),
+
+    # Organization activities
+    url(r'^activity/add/$', al.CreateView.as_view(
+        model=OrganizationActivityField,
+        fields='__all__'),
+        name='organization-activity-add',
+    ),
+    url(r'^activity/(?P<pk>\d+)/edit/$', generic.UpdateView.as_view(
+        model=OrganizationActivityField,
+        fields='__all__'),
+        name='organization-activity-edit',
     ),
 
     # Offices

--- a/ain7/templates/organizations/organizationactivityfield_form.html
+++ b/ain7/templates/organizations/organizationactivityfield_form.html
@@ -1,0 +1,23 @@
+{% extends "emploi/base.html" %}
+{% load i18n %}
+{% load crispy_forms_tags %}
+
+{% block content-left %}
+
+<h2>{{ title }}</h2>
+
+{% if header_msg %}
+    <p>{{ header_msg|safe }}</p>
+{% endif %}
+
+<form method="post" action="." class="form-horizontal">
+{% csrf_token %}
+{{ form|crispy }}
+<div class="control-group">
+<div class="controls">
+<button class="btn btn-primary" type="submit">{% trans "Save" %}</button>
+</div>
+</div>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
Add some links to add some organization objects, with autocomplete-light version 2.3.3.

Link to autocomplete-light module's doc: http://django-autocomplete-light.readthedocs.io/en/2.3.1/addanother.html#autocompletes.
