### PR TITLE
Do not install six 1.11.0 due to an issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,7 @@ MySQL-python
 
 # workaround python-dateutil issue (python 2.x / python 3)
 python-dateutil
+
+# workaround django-autocomplete-light and six issue
+# see https://github.com/yourlabs/django-autocomplete-light/issues/914
+six<1.11


### PR DESCRIPTION
There is an issue between django-autocomplete-light and six 1.11.0 about metaclasses.