### PR TITLE
Add an upper bound to some dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ guppy
 line_profiler
 
 # For the dev
-django-debug-toolbar
+django-debug-toolbar<1.10
 django-nose
 coverage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 Django<1.11
 
-django-allauth
+django-allauth<0.35
 django-autocomplete-light>=2.0,<3.0
 django-crispy-forms
 django-extensions
 django-el-pagination
-django-filter
-django-taggit
+django-filter<2.0
+django-taggit<0.23
 
 celery[redis]<4.0
 


### PR DESCRIPTION
Due to the Django version, those dependencies need an upper bound:
- django-debug-toolbar
- django-allauth
- django-filter
- django-taggit.